### PR TITLE
다양한 이항 연산 추가

### DIFF
--- a/crates/psl/src/ast/expressions.rs
+++ b/crates/psl/src/ast/expressions.rs
@@ -38,4 +38,13 @@ pub enum BinaryOperator {
     Subtract,
     Multiply,
     Divide,
+    Modulus,
+    Equal,
+    NotEqual,
+    Less,
+    Greater,
+    LessEqual,
+    GreaterEqual,
+    LogiacalAnd,
+    LogicalOr,
 }

--- a/crates/psl/src/ast/token.rs
+++ b/crates/psl/src/ast/token.rs
@@ -17,7 +17,13 @@ pub enum TokenKind {
     PunctuationPlusSign,
     PunctuationHyphenMinus,
     PunctuationSolidus,
+    PunctuationPercent,
+    PunctuationAmpersand,
+    PunctuationPipe,
     PonctuationEqualsSign,
+    PunctuationLessSign,
+    PunctuationGreaterSign,
+    PunctuationExclamationMark,
 
     Error,
     Eof,

--- a/crates/psl/src/codegen/impls/expressions/binary_operator.rs
+++ b/crates/psl/src/codegen/impls/expressions/binary_operator.rs
@@ -7,7 +7,9 @@ impl CodegenNode for BinaryOperatorExpression {
     fn produce_code(self, ctx: &mut CodegenContext) -> String {
         let mut output = String::new();
 
+        output.push_str("(");
         output.push_str(&ctx.visit(self.lhs));
+        output.push_str(")");
 
         /*
          * @TODO:
@@ -18,11 +20,22 @@ impl CodegenNode for BinaryOperatorExpression {
             BinaryOperator::Subtract => "-",
             BinaryOperator::Multiply => "*",
             BinaryOperator::Divide => "/",
+            BinaryOperator::Modulus => "%",
+            BinaryOperator::Equal => "==",
+            BinaryOperator::NotEqual => "!=",
+            BinaryOperator::Less => "<",
+            BinaryOperator::Greater => ">",
+            BinaryOperator::LessEqual => "<=",
+            BinaryOperator::GreaterEqual => "<=",
+            BinaryOperator::LogiacalAnd => "&&",
+            BinaryOperator::LogicalOr => "||",
         };
 
         output.push_str(operator);
 
+        output.push_str("(");
         output.push_str(&ctx.visit(self.rhs));
+        output.push_str(")");
 
         output
     }

--- a/crates/psl/src/syntax/expressions/operator.rs
+++ b/crates/psl/src/syntax/expressions/operator.rs
@@ -9,7 +9,58 @@ use crate::ast::{BinaryOperator, BinaryOperatorExpression, Expression, TokenKind
 use super::simple::parse_simple_expression;
 
 pub fn parse_operator(s: &mut Located<&str>) -> PResult<Expression> {
-    parse_addsub_operator.parse_next(s)
+    parse_or_operator.parse_next(s)
+}
+
+pub fn parse_or_operator(s: &mut Located<&str>) -> PResult<Expression> {
+    binary_operator(
+        (TokenKind::PunctuationPipe, TokenKind::PunctuationPipe).map(|_| BinaryOperator::LogicalOr),
+        parse_and_operator,
+    )
+    .parse_next(s)
+}
+
+pub fn parse_and_operator(s: &mut Located<&str>) -> PResult<Expression> {
+    binary_operator(
+        (
+            TokenKind::PunctuationAmpersand,
+            TokenKind::PunctuationAmpersand,
+        )
+            .map(|_| BinaryOperator::LogiacalAnd),
+        parse_comparison_operator,
+    )
+    .parse_next(s)
+}
+
+pub fn parse_comparison_operator(s: &mut Located<&str>) -> PResult<Expression> {
+    binary_operator(
+        alt((
+            (
+                TokenKind::PunctuationLessSign,
+                TokenKind::PonctuationEqualsSign,
+            )
+                .map(|_| BinaryOperator::LessEqual),
+            (
+                TokenKind::PunctuationGreaterSign,
+                TokenKind::PonctuationEqualsSign,
+            )
+                .map(|_| BinaryOperator::GreaterEqual),
+            (
+                TokenKind::PunctuationExclamationMark,
+                TokenKind::PonctuationEqualsSign,
+            )
+                .map(|_| BinaryOperator::NotEqual),
+            (
+                TokenKind::PonctuationEqualsSign,
+                TokenKind::PonctuationEqualsSign,
+            )
+                .map(|_| BinaryOperator::Equal),
+            TokenKind::PunctuationLessSign.map(|_| BinaryOperator::Less),
+            TokenKind::PunctuationGreaterSign.map(|_| BinaryOperator::Greater),
+        )),
+        parse_addsub_operator,
+    )
+    .parse_next(s)
 }
 
 pub fn parse_addsub_operator(s: &mut Located<&str>) -> PResult<Expression> {
@@ -28,6 +79,7 @@ pub fn parse_muldiv_operator(s: &mut Located<&str>) -> PResult<Expression> {
         alt((
             TokenKind::PunctuationAsterisk.map(|_| BinaryOperator::Multiply),
             TokenKind::PunctuationSolidus.map(|_| BinaryOperator::Divide),
+            TokenKind::PunctuationPercent.map(|_| BinaryOperator::Modulus),
         )),
         parse_simple_expression,
     )

--- a/crates/psl/src/syntax/tokens/punctuations.rs
+++ b/crates/psl/src/syntax/tokens/punctuations.rs
@@ -10,7 +10,13 @@ pub fn parse_punctuations(s: &mut Located<&str>) -> PResult<Token> {
         punct("+", TokenKind::PunctuationPlusSign),
         punct("-", TokenKind::PunctuationHyphenMinus),
         punct("/", TokenKind::PunctuationSolidus),
+        punct("%", TokenKind::PunctuationPercent),
+        punct("&", TokenKind::PunctuationAmpersand),
+        punct("|", TokenKind::PunctuationPipe),
         punct("=", TokenKind::PonctuationEqualsSign),
+        punct("!", TokenKind::PunctuationExclamationMark),
+        punct("<", TokenKind::PunctuationLessSign),
+        punct(">", TokenKind::PunctuationGreaterSign),
     ))
     .parse_next(s)
 }

--- a/snippets/24xx/p2420.psl
+++ b/snippets/24xx/p2420.psl
@@ -1,0 +1,4 @@
+i32 N = read i32
+i32 M = read i32
+i32 diff = if N < M then M - N else N - M
+write diff


### PR DESCRIPTION
## 추가된 연산자
`%`: 나머지 연산, round toward zero (`-3 % 2 == -1`), `*` 및 `/`와 같은 우선순위
`==`: 등치 연산, `+` 및 `-`보다 낮은 우선순위
`!=`: 부등 연산, `==`와 같은 우선순위
`<`, `>`, `<=`, `>=`: 일반적인 부등호, `==`와 같은 우선순위
`&&`: 논리곱, `==`보다 낮은 우선순위
`||`: 논리합, `&&`보다 낮은 우선순위 

## 선행 PR
#3 : p2420.psl의 작동에 필요