### PR TITLE
표현식에 infer_type 추가 및 construct::Type 추가

### DIFF
--- a/crates/psl/src/codegen/construct/mod.rs
+++ b/crates/psl/src/codegen/construct/mod.rs
@@ -1,0 +1,3 @@
+pub use r#type::*;
+
+mod r#type;

--- a/crates/psl/src/codegen/construct/type.rs
+++ b/crates/psl/src/codegen/construct/type.rs
@@ -1,0 +1,59 @@
+use std::fmt;
+
+use crate::ast;
+
+#[derive(Clone, PartialEq)]
+pub enum Type {
+    I32,
+    I64,
+    Integer,
+    Bool,
+}
+
+impl TryFrom<ast::Type> for Type {
+    type Error = String;
+
+    fn try_from(value: ast::Type) -> Result<Self, Self::Error> {
+        match value {
+            ast::Type::Simple(token) => match token.content.as_ref() {
+                "i32" => Ok(Type::I32),
+                "i64" => Ok(Type::I64),
+                "bool" => Ok(Type::Bool),
+                _ => Err(format!("THere is no type named {:?}", &token.content)),
+            },
+        }
+    }
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Type::I32 => write!(f, "i32"),
+            Type::I64 => write!(f, "i64"),
+            Type::Integer => write!(f, "{{integer}}"),
+            Type::Bool => write!(f, "bool"),
+        }
+    }
+}
+
+impl Type {
+    pub fn as_c_type(&self) -> String {
+        match self {
+            Type::I32 => "i32".to_string(),
+            Type::I64 => "i64".to_string(),
+            Type::Integer => Type::I32.as_c_type(),
+            Type::Bool => "bool".to_string(),
+        }
+    }
+
+    pub fn union_with(self, other: Type) -> Result<Type, String> {
+        if self == other {
+            return Ok(self);
+        }
+        match (&self, &other) {
+            (Type::I32, Type::Integer) | (Type::Integer, Type::I32) => Ok(Type::I32),
+            (Type::I64, Type::Integer) | (Type::Integer, Type::I64) => Ok(Type::I64),
+            _ => Err(format!("Type {} is not compatible with {}", self, other)),
+        }
+    }
+}

--- a/crates/psl/src/codegen/context.rs
+++ b/crates/psl/src/codegen/context.rs
@@ -6,6 +6,12 @@ pub struct CodegenContext {
     variable_names: HashMap<String, Type>,
 }
 
+impl Default for CodegenContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CodegenContext {
     pub fn new() -> CodegenContext {
         CodegenContext {

--- a/crates/psl/src/codegen/context.rs
+++ b/crates/psl/src/codegen/context.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::ast::Type;
+use super::construct::Type;
 
 pub struct CodegenContext {
     variable_names: HashMap<String, Type>,

--- a/crates/psl/src/codegen/impls/declarations/variable_declaration.rs
+++ b/crates/psl/src/codegen/impls/declarations/variable_declaration.rs
@@ -1,17 +1,16 @@
 use crate::{
-    ast::{Type, VariableDeclaration},
-    codegen::{context::CodegenContext, visitor::CodegenNode},
+    ast::VariableDeclaration,
+    codegen::{construct::Type, context::CodegenContext, visitor::CodegenNode},
 };
 
 impl CodegenNode for VariableDeclaration {
     fn produce_code(self, ctx: &mut CodegenContext) -> String {
-        ctx.add_variable(self.name.content.clone(), self.ty.clone());
+        let ty = Type::try_from(self.ty).unwrap();
+        ctx.add_variable(self.name.content.clone(), ty.clone());
 
         let mut output = String::new();
-        match self.ty {
-            Type::Simple(token) => output.push_str(&token.content),
-        }
 
+        output.push_str(&ty.as_c_type());
         output.push(' ');
         output.push_str(&self.name.content);
 

--- a/crates/psl/src/codegen/impls/expressions/if.rs
+++ b/crates/psl/src/codegen/impls/expressions/if.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::IfExpression,
-    codegen::{context::CodegenContext, visitor::CodegenNode},
+    codegen::{construct::Type, context::CodegenContext, visitor::CodegenNode},
 };
 
 impl CodegenNode for IfExpression {
@@ -16,5 +16,14 @@ impl CodegenNode for IfExpression {
         output.push(')');
 
         output
+    }
+}
+
+impl IfExpression {
+    pub fn infer_type(&self, ctx: &CodegenContext) -> Result<Type, String> {
+        let positive = self.positive.infer_type(ctx)?;
+        let negative = self.negative.infer_type(ctx)?;
+
+        positive.union_with(negative)
     }
 }

--- a/crates/psl/src/codegen/impls/expressions/mod.rs
+++ b/crates/psl/src/codegen/impls/expressions/mod.rs
@@ -5,7 +5,7 @@ mod read;
 
 use crate::{
     ast::Expression,
-    codegen::{context::CodegenContext, visitor::CodegenNode},
+    codegen::{construct::Type, context::CodegenContext, visitor::CodegenNode},
 };
 
 impl CodegenNode for Expression {
@@ -15,6 +15,17 @@ impl CodegenNode for Expression {
             Expression::Name(node) => ctx.visit(node),
             Expression::If(node) => ctx.visit(node),
             Expression::BinaryOperator(node) => ctx.visit(node),
+        }
+    }
+}
+
+impl Expression {
+    pub fn infer_type(&self, ctx: &CodegenContext) -> Result<Type, String> {
+        match self {
+            Expression::Read(expr) => expr.infer_type(ctx),
+            Expression::Name(expr) => expr.infer_type(ctx),
+            Expression::If(expr) => expr.infer_type(ctx),
+            Expression::BinaryOperator(_) => todo!(),
         }
     }
 }

--- a/crates/psl/src/codegen/impls/expressions/name.rs
+++ b/crates/psl/src/codegen/impls/expressions/name.rs
@@ -1,10 +1,18 @@
 use crate::{
     ast::NameExpression,
-    codegen::{context::CodegenContext, visitor::CodegenNode},
+    codegen::{construct::Type, context::CodegenContext, visitor::CodegenNode},
 };
 
 impl CodegenNode for NameExpression {
     fn produce_code(self, _ctx: &mut CodegenContext) -> String {
         self.name.content
+    }
+}
+
+impl NameExpression {
+    pub fn infer_type(&self, ctx: &CodegenContext) -> Result<Type, String> {
+        ctx.get_variable_type(&self.name.content)
+            .cloned()
+            .ok_or_else(|| format!("There is no variable named {:?}", self.name.content))
     }
 }

--- a/crates/psl/src/codegen/impls/expressions/read.rs
+++ b/crates/psl/src/codegen/impls/expressions/read.rs
@@ -1,14 +1,23 @@
 use crate::{
-    ast::{ReadExpression, Type},
-    codegen::{context::CodegenContext, visitor::CodegenNode},
+    ast::ReadExpression,
+    codegen::{construct::Type, context::CodegenContext, visitor::CodegenNode},
 };
 
 impl CodegenNode for ReadExpression {
     fn produce_code(self, _ctx: &mut CodegenContext) -> String {
         match self {
-            ReadExpression::Type(ty) => match ty {
-                Type::Simple(token) => format!("__read_{}(read_buf)", token.content),
-            },
+            ReadExpression::Type(ty) => {
+                let ty = Type::try_from(ty).unwrap();
+                format!("__read_{}(read_buf)", ty.as_c_type())
+            }
+        }
+    }
+}
+
+impl ReadExpression {
+    pub fn infer_type(&self, _ctx: &CodegenContext) -> Result<Type, String> {
+        match self {
+            ReadExpression::Type(ty) => ty.clone().try_into(),
         }
     }
 }

--- a/crates/psl/src/codegen/impls/statements/write.rs
+++ b/crates/psl/src/codegen/impls/statements/write.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{Type, WriteStatement},
+    ast::WriteStatement,
     codegen::{context::CodegenContext, visitor::CodegenNode},
 };
 
@@ -7,14 +7,13 @@ impl CodegenNode for WriteStatement {
     fn produce_code(self, ctx: &mut CodegenContext) -> String {
         let Some(ty) = ctx.get_variable_type(&self.name.name.content) else {
             // @TODO: migrate to diagnostics
-            eprintln!("Cannot compile write statement");
-            return "".to_owned();
+            panic!("There is no variable named {:?}", self.name.name.content);
         };
 
-        let ty = match ty {
-            Type::Simple(token) => &token.content,
-        };
-
-        format!("__write_{}(write_buf, {});\n", ty, self.name.name.content)
+        format!(
+            "__write_{}(write_buf, {});\n",
+            ty.as_c_type(),
+            self.name.name.content
+        )
     }
 }

--- a/crates/psl/src/codegen/mod.rs
+++ b/crates/psl/src/codegen/mod.rs
@@ -2,6 +2,7 @@ use crate::ast::Program;
 
 use self::context::CodegenContext;
 
+pub mod construct;
 mod context;
 mod impls;
 mod visitor;


### PR DESCRIPTION
- 다음 기능 구현을 위해 필요
  - 연쇄 비교식
  - 블록 표현식