### PR TITLE
기타 개선

### DIFF
--- a/crates/psl/src/codegen/impls/expressions/if.rs
+++ b/crates/psl/src/codegen/impls/expressions/if.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::IfExpression,
     codegen::{
-        construct::{Scope, Type},
+        construct::Type,
         context::CodegenContext,
         pass::{NameResolutionContext, NameResolutionPass},
         visitor::CodegenNode,

--- a/crates/psl/src/codegen/impls/statements/mod.rs
+++ b/crates/psl/src/codegen/impls/statements/mod.rs
@@ -13,7 +13,7 @@ impl CodegenNode for Statement {
         match self {
             Statement::Declaration(node) => ctx.visit(node),
             Statement::Write(node) => ctx.visit(node),
-            Statement::Expression(node) => ctx.visit(node),
+            Statement::Expression(node) => format!("{};", ctx.visit(node)),
         }
     }
 }

--- a/crates/psl/src/codegen/pass/name_resolution.rs
+++ b/crates/psl/src/codegen/pass/name_resolution.rs
@@ -14,7 +14,7 @@ pub trait NameResolutionPass {
 
 impl<T: NameResolutionPass> NameResolutionPass for Box<T> {
     fn resolve(&self, ctx: &mut NameResolutionContext) {
-        T::resolve(&self, ctx)
+        T::resolve(self, ctx)
     }
 }
 

--- a/crates/psl/src/syntax/fragments/separator.rs
+++ b/crates/psl/src/syntax/fragments/separator.rs
@@ -7,14 +7,17 @@ use crate::ast::TokenKind;
 
 pub fn parse_separator(s: &mut Located<&str>) -> PResult<()> {
     alt((
-        repeat::<_, _, (), _, _>(
-            1..,
-            (
-                opt(TokenKind::WhitespaceHorizontal),
-                TokenKind::WhitespaceVertical,
+        (
+            repeat::<_, _, (), _, _>(
+                1..,
+                (
+                    opt(TokenKind::WhitespaceHorizontal),
+                    TokenKind::WhitespaceVertical,
+                ),
             ),
+            opt(TokenKind::WhitespaceHorizontal),
         )
-        .void(),
+            .void(),
         TokenKind::Eof.void(),
     ))
     .parse_next(s)

--- a/crates/psl/src/syntax/statements/mod.rs
+++ b/crates/psl/src/syntax/statements/mod.rs
@@ -1,7 +1,7 @@
 mod write;
 
 use winnow::{
-    combinator::{alt, terminated},
+    combinator::{alt, opt, terminated},
     Located, PResult, Parser,
 };
 
@@ -18,7 +18,7 @@ pub fn parse_statement(s: &mut Located<&str>) -> PResult<Statement> {
     alt((
         parse_declaration.map(Statement::Declaration),
         parse_write.map(Statement::Write),
-        terminated(parse_expression, parse_separator).map(Statement::Expression),
+        terminated(parse_expression, opt(parse_separator)).map(Statement::Expression),
     ))
     .parse_next(s)
 }


### PR DESCRIPTION
- 표현식이 문장이 될 때 세미콜론 안 넣는 버그 픽스
- parse_separator가 후행 가로 공백을 제거하도록 함
- 표현식 문장이 꼭 구분자로 끝나지 않아도 되게 함